### PR TITLE
Refactor/add providers and repository interface

### DIFF
--- a/app/Http/Controllers/TransactionController.php
+++ b/app/Http/Controllers/TransactionController.php
@@ -6,10 +6,10 @@ use Illuminate\Http\Request;
 use App\Services\UserService;
 use App\Services\WalletService;
 use App\Exceptions\UserNotFound;
-use App\Services\TransactionService;
 use App\Exceptions\InvalidOperation;
 use App\Exceptions\InsufficientFunds;
 use App\Validators\TransactionValidator;
+use App\Interfaces\Services\TransactionServiceInterface;
 
 class TransactionController extends Controller 
 {
@@ -21,7 +21,7 @@ class TransactionController extends Controller
     public function __construct(
         UserService $userService,
         WalletService $walletService,
-        TransactionService $transactionService,
+        TransactionServiceInterface $transactionService,
         TransactionValidator $validator
     )
     {

--- a/app/Http/Controllers/TransactionController.php
+++ b/app/Http/Controllers/TransactionController.php
@@ -3,13 +3,13 @@ namespace App\Http\Controllers;
 
 use Exception;
 use Illuminate\Http\Request;
-use App\Services\UserService;
-use App\Services\WalletService;
 use App\Exceptions\UserNotFound;
 use App\Exceptions\InvalidOperation;
 use App\Exceptions\InsufficientFunds;
 use App\Validators\TransactionValidator;
 use App\Interfaces\Services\TransactionServiceInterface;
+use App\Interfaces\Services\UserServiceInterface;
+use App\Interfaces\Services\WalletServiceInterface;
 
 class TransactionController extends Controller 
 {
@@ -19,8 +19,8 @@ class TransactionController extends Controller
     protected $validator;
 
     public function __construct(
-        UserService $userService,
-        WalletService $walletService,
+        UserServiceInterface $userService,
+        WalletServiceInterface $walletService,
         TransactionServiceInterface $transactionService,
         TransactionValidator $validator
     )

--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -3,7 +3,7 @@ namespace App\Http\Controllers;
 
 use Exception;
 use Illuminate\Http\Request;
-use App\Services\UserService;
+use App\Interfaces\Services\UserServiceInterface;
 use App\Validators\UserValidator;
 
 class UserController extends Controller
@@ -12,7 +12,7 @@ class UserController extends Controller
     protected $user;
     protected $validator;
 
-    public function __construct(UserService $user, UserValidator $validator)
+    public function __construct(UserServiceInterface $user, UserValidator $validator)
     {
         $this->user = $user;
         $this->validator = $validator;

--- a/app/Http/Controllers/WalletController.php
+++ b/app/Http/Controllers/WalletController.php
@@ -2,14 +2,15 @@
     namespace App\Http\Controllers;
 
     use Exception;
-    use App\Services\UserService;
-    use App\Services\WalletService;
+    use App\Interfaces\Services\UserServiceInterface;
+    use App\Interfaces\Services\WalletServiceInterface;
 
+    
     class WalletController extends Controller {
         protected $user;
         protected $wallet;
 
-        public function __construct(UserService $user, WalletService $wallet) {
+        public function __construct(UserServiceInterface $user, WalletServiceInterface $wallet) {
             $this->user = $user;
             $this->wallet = $wallet;
         }

--- a/app/Http/Interfaces/WalletServiceInterface.php
+++ b/app/Http/Interfaces/WalletServiceInterface.php
@@ -1,7 +1,0 @@
-<?php
-namespace App\Http\Interfaces;
-
-interface WalletServiceInterface
-{
-    public function create(string $userId): void;
-}

--- a/app/Interfaces/Repositories/TransactionRepositoryInterface.php
+++ b/app/Interfaces/Repositories/TransactionRepositoryInterface.php
@@ -1,9 +1,10 @@
 <?php
-namespace App\Http\Interfaces;
+
+namespace App\Interfaces\Repositories;
 
 use App\Models\Transaction;
 
-interface TransactionServiceInterface 
+interface TransactionRepositoryInterface
 {
     public function create($transaction): Transaction;
     public function getByUser(string $userId);

--- a/app/Interfaces/Repositories/UserRepositoryInterface.php
+++ b/app/Interfaces/Repositories/UserRepositoryInterface.php
@@ -1,0 +1,12 @@
+<?php
+namespace App\Interfaces\Repositories;
+
+use App\Models\User;
+
+interface UserRepositoryInterface 
+{
+    public function createWithWallet($userData): User;
+    public function create($userData): User;
+    public function getAll();
+    public function get(string $userId): User;
+}

--- a/app/Interfaces/Repositories/WalletRepositoryInterface.php
+++ b/app/Interfaces/Repositories/WalletRepositoryInterface.php
@@ -1,0 +1,10 @@
+<?php
+namespace App\Interfaces\Repositories;
+
+interface WalletRepositoryInterface 
+{
+    public function create(string $userId);
+    public function getByUser(string $userId);
+    public function getBalance($userId);
+    public function updateBalance(string $userId, float $value);
+}

--- a/app/Interfaces/Services/TransactionServiceInterface.php
+++ b/app/Interfaces/Services/TransactionServiceInterface.php
@@ -1,0 +1,10 @@
+<?php
+namespace App\Interfaces\Services;
+
+use App\Models\Transaction;
+
+interface TransactionServiceInterface 
+{
+    public function create($transaction): Transaction;
+    public function getByUser(string $userId);
+}

--- a/app/Interfaces/Services/UserServiceInterface.php
+++ b/app/Interfaces/Services/UserServiceInterface.php
@@ -1,5 +1,5 @@
 <?php
-namespace App\Http\Interfaces;
+namespace App\Interfaces\Services;
 
 use App\Models\User;
 

--- a/app/Interfaces/Services/WalletServiceInterface.php
+++ b/app/Interfaces/Services/WalletServiceInterface.php
@@ -1,0 +1,11 @@
+<?php
+namespace App\Interfaces\Services;
+
+interface WalletServiceInterface
+{
+    public function create(string $userId): void;
+    public function getBalance(string $userId);
+    public function addMoney(string $userId, float $value);
+    public function debitMoney(string $userId, float $value);
+    public function getByUser(string $userId);
+}

--- a/app/Providers/TransactionServiceProvider.php
+++ b/app/Providers/TransactionServiceProvider.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Providers;
+
+use Illuminate\Support\ServiceProvider;
+
+use App\Services\TransactionService;
+use App\Repositories\TransactionRepository;
+
+use App\Interfaces\Repositories\TransactionRepositoryInterface;
+use App\Interfaces\Services\TransactionServiceInterface;
+
+class TransactionServiceProvider extends ServiceProvider
+{
+    public function register()
+    {
+        $this->app->bind(
+            TransactionRepositoryInterface::class,
+            TransactionRepository::class
+        );
+
+        $this->app->bind(
+            TransactionServiceInterface::class,
+            TransactionService::class
+        );
+    }
+}

--- a/app/Providers/UserServiceProvider.php
+++ b/app/Providers/UserServiceProvider.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Providers;
+
+use Illuminate\Support\ServiceProvider;
+
+use App\Services\UserService;
+use App\Repositories\UserRepository;
+
+use App\Interfaces\Services\UserServiceInterface;
+use App\Interfaces\Repositories\UserRepositoryInterface;
+
+
+class UserServiceProvider extends ServiceProvider
+{
+    public function register()
+    {
+        $this->app->bind(
+            UserRepositoryInterface::class,
+            UserRepository::class
+        );
+
+        $this->app->bind(
+            UserServiceInterface::class,
+            UserService::class
+        );
+    }
+}

--- a/app/Providers/WalletServiceProvider.php
+++ b/app/Providers/WalletServiceProvider.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Providers;
+
+use Illuminate\Support\ServiceProvider;
+
+use App\Repositories\WalletRepository;
+use App\Interfaces\Repositories\WalletRepositoryInterface;
+
+use App\Services\WalletService;
+use App\Interfaces\Services\WalletServiceInterface;
+
+class WalletServiceProvider extends ServiceProvider
+{
+    public function register()
+    {
+        $this->app->bind(
+            WalletRepositoryInterface::class,
+            WalletRepository::class
+        );
+
+        $this->app->bind(
+            WalletServiceInterface::class,
+            WalletService::class
+        );
+    }
+}

--- a/app/Repositories/TransactionRepository.php
+++ b/app/Repositories/TransactionRepository.php
@@ -2,8 +2,10 @@
 namespace App\Repositories;
 
 use App\Models\Transaction;
+use App\Interfaces\Repositories\TransactionRepositoryInterface;
 
-class TransactionRepository {
+class TransactionRepository implements TransactionRepositoryInterface
+{
     public function create($transaction): Transaction
     {
         return Transaction::create($transaction);

--- a/app/Repositories/UserRepository.php
+++ b/app/Repositories/UserRepository.php
@@ -5,9 +5,9 @@ namespace App\Repositories;
 use App\Models\User;
 use App\Services\WalletService;
 use Illuminate\Support\Facades\DB;
+use App\Interfaces\Repositories\UserRepositoryInterface;
 
-
-class UserRepository 
+class UserRepository implements UserRepositoryInterface
 {
     private $wallet;
 

--- a/app/Repositories/WalletRepository.php
+++ b/app/Repositories/WalletRepository.php
@@ -4,8 +4,9 @@ namespace App\Repositories;
 
 use App\Models\Wallet;
 use Illuminate\Support\Facades\DB;
+use App\Interfaces\Repositories\WalletRepositoryInterface;
 
-class WalletRepository
+class WalletRepository implements WalletRepositoryInterface
 {
     public function create(string $userId)
     {

--- a/app/Services/TransactionService.php
+++ b/app/Services/TransactionService.php
@@ -3,10 +3,11 @@ namespace App\Services;
 
 use Exception;
 use App\Models\Transaction;
-use App\Http\Interfaces\TransactionServiceInterface;
+
 use Illuminate\Support\Facades\DB;
 use App\Exceptions\UnauthorizedTransaction;
-use App\Repositories\TransactionRepository;
+use App\Interfaces\Services\TransactionServiceInterface;
+use App\Interfaces\Repositories\TransactionRepositoryInterface;
 
 class TransactionService implements TransactionServiceInterface
 {
@@ -16,12 +17,13 @@ class TransactionService implements TransactionServiceInterface
     protected $authorization;
     protected $transactionRepository;
 
+    //TODO: Receber interfaces do wallet, user, notification e autorization
     public function __construct(
         WalletService $wallet, 
         UserService $user, 
         NotificationService $notification, 
         AuthorizationService $authorization,
-        TransactionRepository $transactionRepository
+        TransactionRepositoryInterface $transactionRepository
     )
     {
         $this->user = $user;

--- a/app/Services/UserService.php
+++ b/app/Services/UserService.php
@@ -6,7 +6,7 @@ use App\Models\User;
 use App\Services\WalletService;
 use App\Exceptions\UserNotFound;
 use Illuminate\Support\Facades\DB;
-use App\Http\Interfaces\UserServiceInterface;
+use App\Interfaces\Services\UserServiceInterface;
 use App\Interfaces\Repositories\UserRepositoryInterface;
 
 class UserService implements UserServiceInterface

--- a/app/Services/UserService.php
+++ b/app/Services/UserService.php
@@ -7,7 +7,7 @@ use App\Services\WalletService;
 use App\Exceptions\UserNotFound;
 use Illuminate\Support\Facades\DB;
 use App\Http\Interfaces\UserServiceInterface;
-use App\Repositories\UserRepository;
+use App\Interfaces\Repositories\UserRepositoryInterface;
 
 class UserService implements UserServiceInterface
 {
@@ -15,7 +15,7 @@ class UserService implements UserServiceInterface
     protected $wallet;
     private $userRepository;
 
-    public function __construct(WalletService $wallet, UserRepository $userRepository)
+    public function __construct(WalletService $wallet, UserRepositoryInterface $userRepository)
     {
         $this->wallet = $wallet;
         $this->userRepository = $userRepository;

--- a/app/Services/UserService.php
+++ b/app/Services/UserService.php
@@ -3,10 +3,10 @@ namespace App\Services;
 
 use Exception;
 use App\Models\User;
-use App\Services\WalletService;
 use App\Exceptions\UserNotFound;
 use Illuminate\Support\Facades\DB;
 use App\Interfaces\Services\UserServiceInterface;
+use App\Interfaces\Services\WalletServiceInterface;
 use App\Interfaces\Repositories\UserRepositoryInterface;
 
 class UserService implements UserServiceInterface
@@ -15,7 +15,7 @@ class UserService implements UserServiceInterface
     protected $wallet;
     private $userRepository;
 
-    public function __construct(WalletService $wallet, UserRepositoryInterface $userRepository)
+    public function __construct(WalletServiceInterface $wallet, UserRepositoryInterface $userRepository)
     {
         $this->wallet = $wallet;
         $this->userRepository = $userRepository;

--- a/app/Services/UserService.php
+++ b/app/Services/UserService.php
@@ -6,18 +6,15 @@ use App\Models\User;
 use App\Exceptions\UserNotFound;
 use Illuminate\Support\Facades\DB;
 use App\Interfaces\Services\UserServiceInterface;
-use App\Interfaces\Services\WalletServiceInterface;
 use App\Interfaces\Repositories\UserRepositoryInterface;
 
 class UserService implements UserServiceInterface
 {
 
-    protected $wallet;
     private $userRepository;
 
-    public function __construct(WalletServiceInterface $wallet, UserRepositoryInterface $userRepository)
+    public function __construct(UserRepositoryInterface $userRepository)
     {
-        $this->wallet = $wallet;
         $this->userRepository = $userRepository;
     }
 

--- a/app/Services/WalletService.php
+++ b/app/Services/WalletService.php
@@ -1,16 +1,15 @@
 <?php
 namespace App\Services;
 
-use App\Models\Wallet;
-use App\Repositories\WalletRepository;
-use App\Http\Interfaces\WalletServiceInterface;
-use Illuminate\Support\Facades\DB;
+
+use App\Interfaces\Services\WalletServiceInterface;
+use App\Interfaces\Repositories\WalletRepositoryInterface;
 
 class WalletService implements WalletServiceInterface
 {
     private $walletRepository;
 
-    public function __construct(WalletRepository $walletRepository)
+    public function __construct(WalletRepositoryInterface $walletRepository)
     {
         $this->walletRepository = $walletRepository;
     }

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -92,6 +92,7 @@ $app->configure('app');
 */
 
 $app->register(Enqueue\LaravelQueue\EnqueueServiceProvider::class);
+$app->register(App\Providers\UserServiceProvider::class);
 // $app->register(App\Providers\AppServiceProvider::class);
 // $app->register(App\Providers\AuthServiceProvider::class);
 // $app->register(App\Providers\EventServiceProvider::class);

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -93,6 +93,7 @@ $app->configure('app');
 
 $app->register(Enqueue\LaravelQueue\EnqueueServiceProvider::class);
 $app->register(App\Providers\UserServiceProvider::class);
+$app->register(App\Providers\WalletServiceProvider::class);
 // $app->register(App\Providers\AppServiceProvider::class);
 // $app->register(App\Providers\AuthServiceProvider::class);
 // $app->register(App\Providers\EventServiceProvider::class);

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -94,6 +94,7 @@ $app->configure('app');
 $app->register(Enqueue\LaravelQueue\EnqueueServiceProvider::class);
 $app->register(App\Providers\UserServiceProvider::class);
 $app->register(App\Providers\WalletServiceProvider::class);
+$app->register(App\Providers\TransactionServiceProvider::class);
 // $app->register(App\Providers\AppServiceProvider::class);
 // $app->register(App\Providers\AuthServiceProvider::class);
 // $app->register(App\Providers\EventServiceProvider::class);


### PR DESCRIPTION
Motivo do PR
Os services e controllers estavam recebendo uma classe concretas de serviços e repositórios como parâmetro no construtor, quando deveriam depender de interfaces não de implementações concretas.

Este pr:
- [x] Substitui a injeção de classes concretas de repositórios e serviços por injeção de interface
- [x] Cria service provider para a classes de `Users, Wallets` e `Transactions`
